### PR TITLE
[WIP] pkgdown site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,6 @@ prepareData/
 ^simulation$
 ^slowtests$
 
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,33 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: pkgdown
+          needs: website
+
+      - name: Deploy package
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, pkgdown]
     tags: ['*']
 
 name: pkgdown

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Rproj.user
 .Rhistory
 riskRegression.Rproj
+docs

--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+```{=html}
+<a href="http://cran.rstudio.com/web/packages/riskRegression/index.html"><img src="http://www.r-pkg.org/badges/version/riskRegression"></a>
+<a href="http://cranlogs.r-pkg.org/downloads/total/last-month/riskRegression"><img src="http://cranlogs.r-pkg.org/badges/riskRegression"></a>
+<a href="https://ci.appveyor.com/project/bozenne/riskRegression"><img src="https://ci.appveyor.com/api/projects/status/github/tagteam/riskRegression?svg=true" alt="Build status"></a>
+<a href="https://github.com/tagteam/riskRegression/actions"><img src="https://github.com/tagteam/riskRegression/workflows/R-CMD-check/badge.svg" alt="R build status"></a>
+```
+# Install
+
+``` {.r org-language="R" exports="both" eval="never"}
+library(devtools)
+install_github("tagteam/riskRegression")
+```
+
+# References
+
+The following references provide the methodological framework for the
+features of riskRegression.
+
+1.  T.A. Gerds and M. Schumacher. Consistent estimation of the expected
+    Brier score in general survival models with right-censored event
+    times. Biometrical Journal, 48(6):1029--1040, 2006.
+
+2.  T.A. Gerds and M. Schumacher. Efron-type measures of prediction
+    error for survival analysis. Biometrics, 63(4):1283--1287, 2007.
+
+3.  T.A. Gerds, T. Cai, and M. Schumacher. The performance of risk
+    prediction models. Biometrical Journal, 50(4):457--479, 2008.
+
+4.  U B Mogensen, H. Ishwaran, and T A Gerds. Evaluating random forests
+    for survival analysis using prediction error curves. Journal of
+    Statistical Software, 50(11), 2012.
+
+5.  P. Blanche, J-F Dartigues, and H. Jacqmin-Gadda. Estimating and
+    comparing time-dependent areas under receiver operating
+    characteristic curves for censored event times with competing risks.
+    Statistics in Medicine, 32(30): 5381--5397, 2013.
+
+6.  Paul Blanche, Ce\'cile Proust-Lima, Lucie Loube\`re, Claudine Berr,
+    Jean- Franc,ois Dartigues, and He\'le\`ne Jacqmin-Gadda. Quantifying
+    and comparing dynamic predictive accuracy of joint models for
+    longitudinal marker and time-to-event in presence of censoring and
+    competing risks. Biometrics, 71 (1):102--113, 2015.
+
+Functions `predict.CauseSpecificCox`{.verbatim}, `predictCox`{.verbatim}
+and `iidCox`{.verbatim}:
+
+-   Brice Ozenne, Anne Lyngholm Sorensen, Thomas Scheike, Christian
+    Torp-Pedersen and Thomas Alexander Gerds. riskRegression: Predicting
+    the Risk of an Event using Cox Regression Models. The R
+    Journal (2017) 9:2, pages 440-460.
+
+```{=latex}
+@article{gerds2006consistent,
+  title =    {Consistent Estimation of the Expected {B}rier Score
+                  in General Survival Models with Right-Censored Event
+                  Times},
+  author =   {Gerds, T.A. and Schumacher, M.},
+  journal =  {Biometrical Journal},
+  volume =   48,
+  number =   6,
+  pages =    {1029--1040},
+  year =     2006,
+  publisher =    {Wiley Online Library}
+}
+
+@article{gerds2007efron,
+  title =    {Efron-Type Measures of Prediction Error for Survival
+                  Analysis},
+  author =   {Gerds, T.A. and Schumacher, M.},
+  journal =  {Biometrics},
+  volume =   63,
+  number =   4,
+  pages =    {1283--1287},
+  year =     2007,
+  publisher =    {Wiley Online Library}
+}
+
+@article{gerds2008performance,
+  title =    {The performance of risk prediction models},
+  author =   {Gerds, T.A. and Cai, T. and Schumacher, M.},
+  journal =  {Biometrical Journal},
+  volume =   50,
+  number =   4,
+  pages =    {457--479},
+  year =     2008,
+  publisher =    {Wiley Online Library}
+}
+
+@Article{mogensen2012pec,
+  title =    {Evaluating random forests for survival analysis
+                  using prediction error curves},
+  author =   {Mogensen, U B and Ishwaran, H. and Gerds, T A},
+  journal =  {Journal of Statistical Software},
+  year =     2012,
+  volume =   50,
+  number =   11
+}
+
+@article{Blanche2013statmed,
+  title =    "{Estimating and comparing time-dependent areas under
+                  receiver operating characteristic curves for
+                  censored event times with competing risks}",
+  author =   {Blanche, P. and Dartigues, J-F and Jacqmin-Gadda,
+                  H.},
+  journal =  {Statistics in Medicine},
+  volume =   32,
+  number =   30,
+  pages =    {5381--5397},
+  year =     2013
+}
+
+@article{blanche2015,
+  title =    {Quantifying and comparing dynamic predictive
+                  accuracy of joint models for longitudinal marker and
+                  time-to-event in presence of censoring and competing
+                  risks},
+  author =   {Blanche, Paul and Proust-Lima, C{\'e}cile and
+                  Loub{\`e}re, Lucie and Berr, Claudine and Dartigues,
+                  Jean-Fran{\c{c}}ois and Jacqmin-Gadda,
+                  H{\'e}l{\`e}ne},
+  journal =  {Biometrics},
+  volume =   71,
+  number =   1,
+  pages =    {102--113},
+  year =     2015,
+  publisher =    {Wiley Online Library}
+}
+
+@article{ozenne2017,
+  title =    {riskRegression: Predicting the Risk of an Event
+                using Cox Regression Modelss},
+  author =   {Ozenne, Brice and Sørensen, Anne Lyngholm 
+                and Scheike, Thomas and Torp-Pedersen, Christian
+                and Gerds, Thomas Alexander},
+  journal =  {The R Journal},
+  volume =   9,
+  number =   2,
+  pages =    {440--460},
+  year =     2017
+}
+```

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -30,6 +30,7 @@ reference:
   - starts_with("coef")
   - starts_with("iid")
   - "influenceTest"
+  - "IC_Nelson_Aalen_cens_time"
   - "IPA"
   - "splitStrataVar"
   - "getSplitMethod"
@@ -50,6 +51,7 @@ reference:
   desc: Plotting methods for models and model diagnostics.
   contents:
   - matches("[Pp]lot")
+
 - title: Utility Functions
 - contents:
   - "discreteRoot"
@@ -58,6 +60,7 @@ reference:
   - starts_with("row")
   - starts_with("slice")
   - starts_with("print")
+
 - title: Data Simulation & Example Datasets
 - contents:
   - reconstructData
@@ -66,3 +69,7 @@ reference:
   - simMelanoma
   - Melanoma
   - Paquid
+
+- title: internal
+- contents:
+  - SmcFcs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,68 @@
+url: ~
+template:
+  bootstrap: 5
+
+reference:
+- title: Regression Modeling
+- subtitle: Model Fitting
+  desc:
+- contents:
+  - "riskRegression"
+  - "riskRegression.options"
+  - "CSC"
+  - "Cforest"
+  - "Ctree"
+  - "FGR"
+  - "penalizedS3"
+  - "selectCox"
+  - "ipcw"
+  - "SuperPredictor"
+  - "wglm"
+- subtitle: Model Utilities
+  desc: Extract model components or calculate associated measures.
+  contents:
+  - starts_with("anova.ate")
+  - "ate"
+  - "baseHaz_cpp"
+  - "boot2pvalue"
+  - starts_with("cox")
+  - starts_with("calcSe")
+  - starts_with("coef")
+  - starts_with("iid")
+  - "influenceTest"
+  - "IPA"
+  - "splitStrataVar"
+  - "getSplitMethod"
+  - starts_with("information")
+  - starts_with("predict")
+  - matches("[Ss]core")
+  - "selectJump"
+  - "SurvResponseVar"
+  - "subjectWeights"
+  - "subsetIndex"
+  - "terms.phreg"
+  - "transformCIBP"
+  - starts_with("confint")
+  - starts_with("model.matrix")
+  - starts_with("summary")
+  - reconstructData
+- subtitle: Visualisation
+  desc: Plotting methods for models and model diagnostics.
+  contents:
+  - matches("[Pp]lot")
+- title: Utility Functions
+- contents:
+  - "discreteRoot"
+  - starts_with("as.data.table")
+  - starts_with("col")
+  - starts_with("row")
+  - starts_with("slice")
+  - starts_with("print")
+- title: Data Simulation & Example Datasets
+- contents:
+  - reconstructData
+  - matches("[Ss]ampleData")
+  - simActiveSurveillance
+  - simMelanoma
+  - Melanoma
+  - Paquid


### PR DESCRIPTION
Turns out this is a little trickier than I hoped.

Preview [is available here](https://jemus42.github.io/riskRegression/index.html)

Working, but WIP:
- Reference index is complete, but only heuristically organized by myself.
- Includes `SmcFcs`, which is undocumented, even though according to pkgdown docs it should be hidden (`title: internal`), which I would have preferred as it is, well, not documented.
- `README` rendering as the site's home page works, but requires converting via `pandoc README.org -o README.md`. Conversion seems to work well and could be easily automated via GitHub Actions for the pkgdown workflow.

Not working yet:
- The IPA vignette would likely need to be converted to RMarkdown, which wouldn't be too hard but I don't want to force it on anyone either.
- Similar thing goes for `NEWS`, as pkgdown expects a `NEWS.md` with a certain heading format.