### PR TITLE
Bug fix for predictRisk.flexsurvreg with a single predictor

### DIFF
--- a/R/predictRisk.R
+++ b/R/predictRisk.R
@@ -1355,7 +1355,7 @@ predictRisk.flexsurvreg <- function(object, newdata, times, ...) {
     newdata <- data.frame(newdata)
     p <- matrix(0, NROW(newdata), length(times))
     term <- attr(terms(as.formula(object$call$formula)), "term.labels")
-    sm <- summary(object, newdata = newdata[, term], t = times, start = 0, B = 0) #no confidence interval simulations
+    sm <- summary(object, newdata = newdata[, term, drop = FALSE], t = times, start = 0, B = 0) #no confidence interval simulations
     for (i in 1:NROW(newdata)){
         p[i,] <- sm[[i]][,2]
     }


### PR DESCRIPTION
Hi,

I was having some issues when using the `Score()` and `predictRisk()` functions with {flexsurv} models, both `flexsurvreg()` and `flexsurvspline()`:

``` r
library(flexsurv)
#> Loading required package: survival
library(riskRegression)
#> riskRegression version 2023.12.21
library(rstpm2)
#> Loading required package: splines
#> 
#> Attaching package: 'rstpm2'
#> The following object is masked from 'package:survival':
#> 
#>     colon

data(brcancer, package = "rstpm2")

m1 <- flexsurvreg(Surv(rectime, censrec == 1) ~ hormon, data = brcancer, dist = "weibull")
Score(
  list(m1),
  formula = update(m1$all.formulae$scale, . ~ 1),
  data = brcancer
)
#> Error in form.model.matrix(x, as.data.frame(newdata), na.action = na.action): Value of covariate "hormon" not supplied in "newdata"
class(m1)
#> [1] "flexsurvreg"

m2 <- flexsurvspline(Surv(rectime, censrec == 1) ~ hormon, k = 5, data = brcancer)
Score(
  list(m2),
  formula = update(m1$all.formulae$scale, . ~ 1),
  data = brcancer
)
#> Error in form.model.matrix(x, as.data.frame(newdata), na.action = na.action): Value of covariate "hormon" not supplied in "newdata"
class(m2)
#> [1] "flexsurvreg"

riskRegression:::predictRisk.flexsurvreg(object = m1, newdata = brcancer, times = mean(brcancer$rectime))
#> Error in form.model.matrix(x, as.data.frame(newdata), na.action = na.action): Value of covariate "hormon" not supplied in "newdata"
```


I think this has to do with having a single predictor in the model, as the following seemed to work fine:

``` r
m3 <- flexsurvspline(Surv(rectime, censrec == 1) ~ hormon + x1, k = 5, data = brcancer)
Score(
  list(m3),
  formula = update(m1$all.formulae$scale, . ~ 1),
  data = brcancer
)
#> 
#> Metric AUC:
#> 
#> Results by model:
#> 
#>          model times  AUC lower upper
#> 1: flexsurvreg  1060 54.5  49.6  59.4
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The higher AUC the better.
#> 
#> Metric Brier:
#> 
#> Results by model:
#> 
#>          model  times Brier lower upper
#> 1:  Null model 1060.5  22.7  21.6  23.9
#> 2: flexsurvreg 1060.5  22.5  21.4  23.7
#> 
#> Results of model comparisons:
#> 
#>     times       model  reference delta.Brier lower upper         p
#> 1: 1060.5 flexsurvreg Null model        -0.2  -0.6   0.1 0.2392693
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The lower Brier the better.
```

I think the issue is here:

https://github.com/tagteam/riskRegression/blob/499ba2d3e9e798d91c6d272932dd7d1b455e9122/R/predictRisk.R#L1358

...where `newdata[, term]` turns into a vector if `term` is a single term.

With this PR, I added the argument `drop = FALSE` to the above to ensure that `newdata` is not turned into a vector, which seems to fix the issue:

``` r
library(flexsurv)
#> Loading required package: survival
library(riskRegression)
#> riskRegression version 2023.12.19
library(rstpm2)
#> Loading required package: splines
#> 
#> Attaching package: 'rstpm2'
#> The following object is masked from 'package:survival':
#> 
#>     colon

data(brcancer, package = "rstpm2")

m1 <- flexsurvreg(Surv(rectime, censrec == 1) ~ hormon, data = brcancer, dist = "weibull")
Score(
  list(m1),
  formula = update(m1$all.formulae$scale, . ~ 1),
  data = brcancer
)
#> 
#> Metric AUC:
#> 
#> Results by model:
#> 
#>          model times  AUC lower upper
#> 1: flexsurvreg  1060 54.9  51.0  58.9
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The higher AUC the better.
#> 
#> Metric Brier:
#> 
#> Results by model:
#> 
#>          model  times Brier lower upper
#> 1:  Null model 1060.5  22.7  21.6  23.9
#> 2: flexsurvreg 1060.5  22.6  21.2  24.0
#> 
#> Results of model comparisons:
#> 
#>     times       model  reference delta.Brier lower upper         p
#> 1: 1060.5 flexsurvreg Null model        -0.1  -0.5   0.3 0.5644279
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The lower Brier the better.
class(m1)
#> [1] "flexsurvreg"

m2 <- flexsurvspline(Surv(rectime, censrec == 1) ~ hormon, k = 5, data = brcancer)
Score(
  list(m2),
  formula = update(m1$all.formulae$scale, . ~ 1),
  data = brcancer
)
#> 
#> Metric AUC:
#> 
#> Results by model:
#> 
#>          model times  AUC lower upper
#> 1: flexsurvreg  1060 54.9  51.0  58.9
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The higher AUC the better.
#> 
#> Metric Brier:
#> 
#> Results by model:
#> 
#>          model  times Brier lower upper
#> 1:  Null model 1060.5  22.7  21.6  23.9
#> 2: flexsurvreg 1060.5  22.5  21.4  23.7
#> 
#> Results of model comparisons:
#> 
#>     times       model  reference delta.Brier lower upper         p
#> 1: 1060.5 flexsurvreg Null model        -0.2  -0.6   0.1 0.2382545
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The lower Brier the better.
class(m2)
#> [1] "flexsurvreg"

m3 <- flexsurvspline(Surv(rectime, censrec == 1) ~ hormon + x1, k = 5, data = brcancer)
Score(
  list(m3),
  formula = update(m1$all.formulae$scale, . ~ 1),
  data = brcancer
)
#> 
#> Metric AUC:
#> 
#> Results by model:
#> 
#>          model times  AUC lower upper
#> 1: flexsurvreg  1060 54.5  49.6  59.4
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The higher AUC the better.
#> 
#> Metric Brier:
#> 
#> Results by model:
#> 
#>          model  times Brier lower upper
#> 1:  Null model 1060.5  22.7  21.6  23.9
#> 2: flexsurvreg 1060.5  22.5  21.4  23.7
#> 
#> Results of model comparisons:
#> 
#>     times       model  reference delta.Brier lower upper         p
#> 1: 1060.5 flexsurvreg Null model        -0.2  -0.6   0.1 0.2392693
#> 
#> NOTE: Values are multiplied by 100 and given in %.
#> NOTE: The lower Brier the better.

head(riskRegression:::predictRisk.flexsurvreg(object = m1, newdata = brcancer, times = mean(brcancer$rectime)))
#>           [,1]
#> [1,] 0.3765336
#> [2,] 0.2730138
#> [3,] 0.2730138
#> [4,] 0.2730138
#> [5,] 0.3765336
#> [6,] 0.3765336
```

I didn't run the package tests, so I am not sure if this breaks something else – please just let me know if you'd like me to amend this PR in any way.

Many thanks,


Alessandro